### PR TITLE
Consider using -task blastp-fast

### DIFF
--- a/workflows/Annotation/transcriptome_annotation.cwl
+++ b/workflows/Annotation/transcriptome_annotation.cwl
@@ -74,6 +74,8 @@ steps:
         source: transdecoder_longorfs_extract_result/output
       - id: max_target_seqs
         default: 1000
+      - id: task
+        default: blastp-fast
       - id: out
         valueFrom: '${ return inputs.query.nameroot + "_blastp.tsv";}'
     out:


### PR DESCRIPTION
This task uses a larger word-size and word threshold, leading to faster run times (see https://www.ncbi.nlm.nih.gov/books/NBK279684/table/appendices.T.blastp_application_options/ for additional details)